### PR TITLE
EPA-435 Cache Konnektor data

### DIFF
--- a/common/src/main/java/de/servicehealth/logging/LogField.java
+++ b/common/src/main/java/de/servicehealth/logging/LogField.java
@@ -27,6 +27,7 @@ public enum LogField {
     REQUEST_CORRELATION_ID("requestCorrelationId"),
     CT_ID("ctid"),
     SLOT("slot"),
+    CLIENT_UUID("clientUuid"),
     WORKPLACE("workPlaceId");
 
     private final String identifier;

--- a/common/src/main/java/de/servicehealth/startup/StartableService.java
+++ b/common/src/main/java/de/servicehealth/startup/StartableService.java
@@ -12,7 +12,9 @@ public abstract class StartableService implements StartupEventListener {
 
     public static final int CxfClientFactoryPriority = 1000;
     public static final int MultiEpaPriority = 2000;
-    public static final int VauNpProviderPriority = 3000;
+    public static final int KonnektorClientPriority = 3000;
+    public static final int VauSessionsJobPriority = 4000;
+    public static final int VauNpProviderPriority = 5000;
 
     private final Logger log = LoggerFactory.getLogger(getClass().getSimpleName());
 

--- a/rest-server/pom.xml
+++ b/rest-server/pom.xml
@@ -189,9 +189,9 @@
                     <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
                     <includeOnlyProperties>
                         <includeOnlyProperty>^git.build.time$</includeOnlyProperty>
-                        <includeOnlyProperty>^git.commit.id.full$</includeOnlyProperty>
+                        <includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
                     </includeOnlyProperties>
-                    <commitIdGenerationMode>full</commitIdGenerationMode>
+                    <commitIdGenerationMode>flat</commitIdGenerationMode>
                 </configuration>
             </plugin>
 

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/cetp/cache/SmcbCertificateFile.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/cetp/cache/SmcbCertificateFile.java
@@ -1,0 +1,64 @@
+package de.servicehealth.epa4all.server.cetp.cache;
+
+import de.health.service.cetp.CertificateInfo;
+import de.servicehealth.epa4all.server.file.MapDumpFile;
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Map;
+
+import static de.health.service.cetp.konnektorconfig.FSConfigService.CONFIG_DELIMETER;
+
+public class SmcbCertificateFile extends MapDumpFile<String, CertificateInfo> {
+
+    public static final String SMCB_CERTIFICATE_FILE_NAME = "smcb-certificate";
+
+    public SmcbCertificateFile(File folder) throws IOException {
+        super(folder);
+    }
+
+    @Override
+    protected String getFileName() {
+        return SMCB_CERTIFICATE_FILE_NAME;
+    }
+
+    @Override
+    protected Pair<String, CertificateInfo> deserialize(String line) {
+        String[] parts = line.split(CONFIG_DELIMETER);
+        String smcb = parts[0].trim();
+        String signatureType = parts[1].trim();
+        String base64Certificate = parts[2].trim();
+        byte[] decoded = Base64.getDecoder().decode(base64Certificate);
+        try (ObjectInputStream is = new ObjectInputStream(new ByteArrayInputStream(decoded))) {
+            X509Certificate certificate = (X509Certificate) is.readObject();
+            return Pair.of(smcb, new CertificateInfo(certificate, signatureType));
+        } catch (Exception e) {
+            log.error(String.format("Unable to read '%s' file: %s", SMCB_CERTIFICATE_FILE_NAME, e.getMessage()));
+        }
+        return null;
+    }
+
+    @Override
+    protected String serialize(Map.Entry<String, CertificateInfo> entry) {
+        String smcb = entry.getKey();
+        CertificateInfo certificateInfo = entry.getValue();
+        String signatureType = certificateInfo.getSignatureType();
+        X509Certificate certificate = certificateInfo.getCertificate();
+        ByteArrayOutputStream byteArrayStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream os = new ObjectOutputStream(byteArrayStream)) {
+            os.writeObject(certificate);
+        } catch (Exception e) {
+            log.error(String.format("Unable to store '%s' file: %s", SMCB_CERTIFICATE_FILE_NAME, e.getMessage()));
+            return null;
+        }
+        String base64Certificate = Base64.getEncoder().encodeToString(byteArrayStream.toByteArray());
+        return String.join(CONFIG_DELIMETER, smcb, signatureType, base64Certificate);
+    }
+}

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/check/GitCheck.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/check/GitCheck.java
@@ -32,7 +32,7 @@ public class GitCheck implements Check {
 
     void onStart(@Observes StartupEvent ev) {
         log.info("{}: {}", BUILD_TIME, properties.getProperty("git.build.time"));
-        log.info("{}: {}", GIT_COMMIT_ID, properties.getProperty("git.commit.id.full"));
+        log.info("{}: {}", GIT_COMMIT_ID, properties.getProperty("git.commit.id"));
     }
 
     @Override
@@ -49,7 +49,7 @@ public class GitCheck implements Check {
     public Map<String, Object> getData(IRuntimeConfig runtimeConfig) {
         return Map.of(
             BUILD_TIME, properties.getProperty("git.build.time"),
-            GIT_COMMIT_ID, properties.getProperty("git.commit.id.full")
+            GIT_COMMIT_ID, properties.getProperty("git.commit.id")
         );
     }
 }

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/entitlement/EntitlementFile.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/entitlement/EntitlementFile.java
@@ -46,6 +46,6 @@ public class EntitlementFile extends MapDumpFile<String, Instant> {
     public void updateEntitlement(Instant validTo) {
         Map<String, Instant> map = get();
         map.put(insurantId, validTo);
-        update(map);
+        overwrite(map);
     }
 }

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/file/StringKeyValueFile.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/file/StringKeyValueFile.java
@@ -1,0 +1,29 @@
+package de.servicehealth.epa4all.server.file;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import static de.health.service.cetp.konnektorconfig.FSConfigService.CONFIG_DELIMETER;
+
+public abstract class StringKeyValueFile extends MapDumpFile<String, String> {
+
+    public StringKeyValueFile(File folder) throws IOException {
+        super(folder);
+    }
+
+    @Override
+    protected Pair<String, String> deserialize(String line) {
+        String[] parts = line.split(CONFIG_DELIMETER);
+        String key = parts[0].trim();
+        String value = parts[1].trim();
+        return Pair.of(key, value);
+    }
+
+    @Override
+    protected String serialize(Map.Entry<String, String> entry) {
+        return String.join(CONFIG_DELIMETER, entry.getKey(), entry.getValue());
+    }
+}

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/idp/IdpClient.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/idp/IdpClient.java
@@ -14,7 +14,7 @@ import de.servicehealth.epa4all.server.idp.action.AuthAction;
 import de.servicehealth.epa4all.server.idp.action.LoginAction;
 import de.servicehealth.epa4all.server.idp.action.VauNpAction;
 import de.servicehealth.epa4all.server.idp.func.IdpFunc;
-import de.servicehealth.epa4all.server.serviceport.IKonnektorServicePortsAPI;
+import de.servicehealth.epa4all.server.serviceport.IKonnektorAPI;
 import de.servicehealth.epa4all.server.serviceport.MultiKonnektorService;
 import de.servicehealth.model.SendAuthCodeSCtype;
 import de.servicehealth.startup.StartableService;
@@ -119,7 +119,7 @@ public class IdpClient extends StartableService {
         UserRuntimeConfig runtimeConfig,
         Consumer<SendAuthCodeSCtype> authCodeConsumer
     ) {
-        IKonnektorServicePortsAPI servicePorts = multiKonnektorService.getServicePorts(runtimeConfig);
+        IKonnektorAPI servicePorts = multiKonnektorService.getServicePorts(runtimeConfig);
         IdpFunc idpFunc = IdpFunc.init(servicePorts);
         VauNpAction authAction = new VauNpAction(
             authenticatorClient,
@@ -250,7 +250,7 @@ public class IdpClient extends StartableService {
         String hcv,
         UserRuntimeConfig userRuntimeConfig
     ) {
-        IKonnektorServicePortsAPI servicePorts = multiKonnektorService.getServicePorts(userRuntimeConfig);
+        IKonnektorAPI servicePorts = multiKonnektorService.getServicePorts(userRuntimeConfig);
         JwtClaims claims = new JwtClaims();
         claims.setClaim(ClaimName.ISSUED_AT.getJoseName(), System.currentTimeMillis() / 1000);
         claims.setClaim(ClaimName.EXPIRES_AT.getJoseName(), (System.currentTimeMillis() / 1000) + 1200);
@@ -273,7 +273,7 @@ public class IdpClient extends StartableService {
         UserRuntimeConfig userRuntimeConfig,
         Consumer<String> bearerConsumer
     ) throws Exception {
-        IKonnektorServicePortsAPI servicePorts = multiKonnektorService.getServicePorts(userRuntimeConfig);
+        IKonnektorAPI servicePorts = multiKonnektorService.getServicePorts(userRuntimeConfig);
         IdpFunc idpFunc = IdpFunc.init(servicePorts);
         LoginAction authAction = new LoginAction(
             idpConfig.getClientId(),

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/idp/func/IdpFunc.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/idp/func/IdpFunc.java
@@ -4,7 +4,7 @@ import de.gematik.ws.conn.authsignatureservice.wsdl.v7_4.FaultMessage;
 import de.gematik.ws.conn.connectorcontext.v2.ContextType;
 import de.gematik.ws.conn.signatureservice.v7.ExternalAuthenticate;
 import de.gematik.ws.conn.signatureservice.v7.ExternalAuthenticateResponse;
-import de.servicehealth.epa4all.server.serviceport.IKonnektorServicePortsAPI;
+import de.servicehealth.epa4all.server.serviceport.IKonnektorAPI;
 import lombok.Getter;
 
 import java.util.function.Function;
@@ -24,7 +24,7 @@ public class IdpFunc {
         this.extAuthFunc = extAuthFunc;
     }
 
-    public static IdpFunc init(IKonnektorServicePortsAPI servicePorts) {
+    public static IdpFunc init(IKonnektorAPI servicePorts) {
         return new IdpFunc(
             servicePorts::getContextType,
             externalAuthenticate -> {

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/idp/vaunp/VauNpProvider.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/idp/vaunp/VauNpProvider.java
@@ -48,6 +48,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static de.health.service.cetp.konnektorconfig.FSConfigService.CONFIG_DELIMETER;
 import static de.servicehealth.logging.LogContext.withMdcNr;
 import static de.servicehealth.logging.LogField.BACKEND;
+import static de.servicehealth.logging.LogField.CLIENT_UUID;
 import static de.servicehealth.logging.LogField.KONNEKTOR;
 import static de.servicehealth.logging.LogField.SMCB_HANDLE;
 import static de.servicehealth.logging.LogField.WORKPLACE;
@@ -225,16 +226,17 @@ public class VauNpProvider extends StartableService {
     ) {
         try {
             KonnektorWorkplaceInfo info = getKonnektorWorkplaceInfo(konnektorWorkplace);
+            String uuid = vauClient.getUuid();
             Map<LogField, String> mdcMap = Map.of(
                 BACKEND, backend,
                 SMCB_HANDLE, smcbHandle,
                 KONNEKTOR, info.konnektor,
-                WORKPLACE, info.workplaceId
+                WORKPLACE, info.workplaceId,
+                CLIENT_UUID, uuid
             );
             withMdcNr(mdcMap, () -> {
                 vauHandshake.get().apply(uri, vauClient);
                 // A_24881 - Nonce anfordern für Erstellung "Attestation der Umgebung"
-                String uuid = vauClient.getUuid();
                 String nonce = smcBApi.getNonce(clientId, userAgent, backend, uuid).getNonce();
                 try (Response response = smcBApi.sendAuthRequest(clientId, userAgent, backend, uuid)) {
                     URI location = response.getLocation();

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/serviceport/IKonnektorAPI.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/serviceport/IKonnektorAPI.java
@@ -7,7 +7,7 @@ import de.gematik.ws.conn.connectorcontext.v2.ContextType;
 import de.gematik.ws.conn.eventservice.wsdl.v7_2.EventServicePortType;
 import de.gematik.ws.conn.vsds.vsdservice.v5_2.VSDServicePortType;
 
-public interface IKonnektorServicePortsAPI {
+public interface IKonnektorAPI {
 
     ContextType getContextType();
 
@@ -16,6 +16,8 @@ public interface IKonnektorServicePortsAPI {
     EventServicePortType getEventService();
 
     VSDServicePortType getVSDServicePortType();
+
+    EventServicePortType getEventServiceSilent();
 
     CertificateServicePortType getCertificateService();
 

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/serviceport/KonnektorServicePorts.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/serviceport/KonnektorServicePorts.java
@@ -7,19 +7,21 @@ import de.gematik.ws.conn.connectorcontext.v2.ContextType;
 import de.gematik.ws.conn.eventservice.wsdl.v7_2.EventServicePortType;
 import de.gematik.ws.conn.vsds.vsdservice.v5_2.VSDServicePortType;
 
-public class KonnektorServicePortAggregator implements IKonnektorServicePortsAPI {
+public class KonnektorServicePorts implements IKonnektorAPI {
 
     private final ContextType contextType;
     private final CardServicePortType cardService;
+    private final EventServicePortType eventServiceSilent;
     private final EventServicePortType eventService;
     private final VSDServicePortType vsdServicePortType;
     private final CertificateServicePortType certificateService;
     private final AuthSignatureServicePortType authSignatureService;
 
-    public KonnektorServicePortAggregator(
+    public KonnektorServicePorts(
         ContextType contextType,
         CardServicePortType cardService,
         EventServicePortType eventService,
+        EventServicePortType eventServiceSilent,
         VSDServicePortType vsdServicePortType,
         CertificateServicePortType certificateService,
         AuthSignatureServicePortType authSignatureService
@@ -27,6 +29,7 @@ public class KonnektorServicePortAggregator implements IKonnektorServicePortsAPI
         this.contextType = contextType;
         this.cardService = cardService;
         this.eventService = eventService;
+        this.eventServiceSilent = eventServiceSilent;
         this.vsdServicePortType = vsdServicePortType;
         this.certificateService = certificateService;
         this.authSignatureService = authSignatureService;
@@ -40,6 +43,11 @@ public class KonnektorServicePortAggregator implements IKonnektorServicePortsAPI
     @Override
     public CardServicePortType getCardService() {
         return cardService;
+    }
+
+    @Override
+    public EventServicePortType getEventServiceSilent() {
+        return eventServiceSilent;
     }
 
     @Override

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/serviceport/MultiKonnektorService.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/serviceport/MultiKonnektorService.java
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class MultiKonnektorService {
 
     @Getter
-    private final ConcurrentHashMap<KonnektorKey, IKonnektorServicePortsAPI> portMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<KonnektorKey, IKonnektorAPI> portMap = new ConcurrentHashMap<>();
 
     private final ServicePortProvider servicePortProvider;
 
@@ -26,20 +26,22 @@ public class MultiKonnektorService {
         this.servicePortProvider = servicePortProvider;
     }
 
-    public IKonnektorServicePortsAPI getServicePorts(UserRuntimeConfig userRuntimeConfig) {
+    public IKonnektorAPI getServicePorts(UserRuntimeConfig userRuntimeConfig) {
         return portMap.computeIfAbsent(new KonnektorKey(userRuntimeConfig), kk -> {
             CardServicePortType cardServicePortType = servicePortProvider.getCardServicePortType(userRuntimeConfig);
             EventServicePortType eventServicePort = servicePortProvider.getEventServicePort(userRuntimeConfig);
+            EventServicePortType eventServicePortSilent = servicePortProvider.getEventServicePortSilent(userRuntimeConfig);
             VSDServicePortType vsdServicePortType = servicePortProvider.getVSDServicePortType(userRuntimeConfig);
             CertificateServicePortType certificateService = servicePortProvider.getCertificateServicePort(userRuntimeConfig);
             AuthSignatureServicePortType authSignatureService = servicePortProvider.getAuthSignatureServicePortType(userRuntimeConfig);
 
             servicePortProvider.saveEndpointsConfiguration();
 
-            return new KonnektorServicePortAggregator(
+            return new KonnektorServicePorts(
                 buildContextType(userRuntimeConfig),
                 cardServicePortType,
                 eventServicePort,
+                eventServicePortSilent,
                 vsdServicePortType,
                 certificateService,
                 authSignatureService

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/serviceport/ServicePortProvider.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/serviceport/ServicePortProvider.java
@@ -73,7 +73,7 @@ public class ServicePortProvider extends StartableService {
 
     void saveEndpointsConfiguration() {
         try {
-            new ServicePortFile(configDirectory).update(konnektorsEndpoints);
+            new ServicePortFile(configDirectory).overwrite(konnektorsEndpoints);
         } catch (Exception e) {
             log.error("Error while saving service-ports file", e);
         }
@@ -151,6 +151,17 @@ public class ServicePortProvider extends StartableService {
         setEndpointAddress((BindingProvider) authSignatureServicePort, url, sslContext);
 
         return authSignatureServicePort;
+    }
+
+    public EventServicePortType getEventServicePortSilent(UserRuntimeConfig userRuntimeConfig) {
+        SSLContext sslContext = getSSLContext(userRuntimeConfig.getUserConfigurations());
+        EventService eventService = new EventService();
+        EventServicePortType eventServicePort = eventService.getEventServicePort();
+        String connectorBaseURL = userRuntimeConfig.getUserConfigurations().getConnectorBaseURL();
+        String url = konnektorsEndpoints.get(connectorBaseURL).get("eventServiceEndpointAddress");
+        setEndpointAddress((BindingProvider) eventServicePort, url, sslContext);
+
+        return eventServicePort;
     }
 
     public EventServicePortType getEventServicePort(UserRuntimeConfig userRuntimeConfig) {

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/vsd/VsdService.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/vsd/VsdService.java
@@ -8,7 +8,7 @@ import de.health.service.cetp.domain.fault.CetpFault;
 import de.health.service.config.api.UserRuntimeConfig;
 import de.servicehealth.epa4all.server.epa.EpaCallGuard;
 import de.servicehealth.epa4all.server.filetracker.FolderService;
-import de.servicehealth.epa4all.server.serviceport.IKonnektorServicePortsAPI;
+import de.servicehealth.epa4all.server.serviceport.IKonnektorAPI;
 import de.servicehealth.epa4all.server.serviceport.MultiKonnektorService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -72,7 +72,7 @@ public class VsdService {
         String telematikId,
         String fallbackKvnr
     ) throws Exception {
-        IKonnektorServicePortsAPI servicePorts = multiKonnektorService.getServicePorts(runtimeConfig);
+        IKonnektorAPI servicePorts = multiKonnektorService.getServicePorts(runtimeConfig);
         ContextType context = servicePorts.getContextType();
         if (context.getUserId() == null || context.getUserId().isEmpty()) {
             context.setUserId(UUID.randomUUID().toString());


### PR DESCRIPTION
* Insurant egk handles are cached into file
* Smcb X509Certificates are cached into file
* Subscription RESP_IN/RESP_OUT logs are disabled
* GitCheck shows short git-commit
* Logging is improved