### PR TITLE
EPA-487: Expose epa4All API that 3rd party can listen or connect to get CETP events

### DIFF
--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/cetp/CETPServerHandlerFactory.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/cetp/CETPServerHandlerFactory.java
@@ -13,6 +13,7 @@ import de.servicehealth.epa4all.server.entitlement.EntitlementService;
 import de.servicehealth.epa4all.server.epa.EpaCallGuard;
 import de.servicehealth.epa4all.server.filetracker.download.EpaFileDownloader;
 import de.servicehealth.epa4all.server.insurance.InsuranceDataService;
+import de.servicehealth.epa4all.server.ws.CETPPayload;
 import de.servicehealth.epa4all.server.ws.WebSocketPayload;
 import io.netty.channel.ChannelInboundHandler;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -31,6 +32,7 @@ public class CETPServerHandlerFactory implements CETPEventHandlerFactory {
     private final InsuranceDataService insuranceDataService;
     private final CardlinkClientWSFactory cardlinkClientFactory;
     private final Event<WebSocketPayload> webSocketPayloadEvent;
+    private final Event<CETPPayload> cetpPayloadEvent;
     private final KonnektorDefaultConfig konnektorDefaultConfig;
 
     @Inject
@@ -44,6 +46,7 @@ public class CETPServerHandlerFactory implements CETPEventHandlerFactory {
         InsuranceDataService insuranceDataService,
         CardlinkClientWSFactory cardlinkClientFactory,
         Event<WebSocketPayload> webSocketPayloadEvent,
+        Event<CETPPayload> cetpPayloadEvent,
         KonnektorDefaultConfig konnektorDefaultConfig
     ) {
         this.epaCallGuard = epaCallGuard;
@@ -54,6 +57,7 @@ public class CETPServerHandlerFactory implements CETPEventHandlerFactory {
         this.entitlementService = entitlementService;
         this.insuranceDataService = insuranceDataService;
         this.webSocketPayloadEvent = webSocketPayloadEvent;
+        this.cetpPayloadEvent = cetpPayloadEvent;
         this.cardlinkClientFactory = cardlinkClientFactory;
         this.konnektorDefaultConfig = konnektorDefaultConfig;
     }
@@ -63,8 +67,8 @@ public class CETPServerHandlerFactory implements CETPEventHandlerFactory {
         RuntimeConfig runtimeConfig = new RuntimeConfig(konnektorDefaultConfig, konnektorConfig.getUserConfigurations());
         CardlinkClient cardlinkClient = cardlinkClientFactory.build(konnektorConfig);
         CETPEventHandler cetpEventHandler = new CETPEventHandler(
-            webSocketPayloadEvent, insuranceDataService, entitlementService, epaFileDownloader, konnektorClient,
-            epaMultiService, cardlinkClient, runtimeConfig, featureConfig, epaCallGuard
+            webSocketPayloadEvent, cetpPayloadEvent, insuranceDataService, entitlementService, epaFileDownloader,
+            konnektorClient, epaMultiService, cardlinkClient, runtimeConfig, featureConfig, epaCallGuard
         );
         return new ChannelInboundHandler[] { cetpEventHandler };
     }

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/ws/CETPPayload.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/ws/CETPPayload.java
@@ -1,0 +1,31 @@
+package de.servicehealth.epa4all.server.ws;
+
+import jakarta.json.bind.annotation.JsonbProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CETPPayload {
+
+    @JsonbProperty("smcbHandle")
+    String smcbHandle;
+
+    @JsonbProperty("telematikId")
+    String telematikId;
+
+    @JsonbProperty("kvnr")
+    String kvnr;
+
+    @JsonbProperty("error")
+    String error;
+
+    @JsonbProperty("parameters")
+    Map<String, String> parameters;
+}

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/ws/CETPWebsocket.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/ws/CETPWebsocket.java
@@ -1,0 +1,59 @@
+package de.servicehealth.epa4all.server.ws;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.ObservesAsync;
+import jakarta.websocket.OnClose;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.server.ServerEndpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@SuppressWarnings("unused")
+@ServerEndpoint(value = "/ws/cetp", encoders = {JsonEncoder.class})
+@ApplicationScoped
+public class CETPWebsocket {
+
+    private static final Logger log = LoggerFactory.getLogger(TelematikWebsocket.class.getName());
+
+    Map<Session, Boolean> sessions = new ConcurrentHashMap<>();
+
+    public void onTransfer(@ObservesAsync CETPPayload cetpPayload) {
+        sendMessage(cetpPayload);
+    }
+
+    private <T> void sendMessage(T message) {
+        sessions.keySet().forEach(session -> session.getAsyncRemote().sendObject(message, result -> {
+            if (result.getException() != null) {
+                log.error("Unable to send CETP payload", result.getException());
+            }
+        }));
+    }
+
+    @OnOpen
+    public void onOpen(Session session) {
+        sessions.put(session, true);
+        sendMessage("CETP SESSION is created");
+    }
+
+    @OnClose
+    public void onClose(Session session) {
+        sessions.remove(session);
+    }
+
+    @OnError
+    public void onError(Session session, Throwable throwable) {
+        sessions.remove(session);
+        sendMessage("CETP SESSION error: " + throwable.getMessage());
+    }
+
+    @OnMessage
+    public void onMessage(String message) {
+        log.info("CETP SESSION message: " + message);
+    }
+}

--- a/rest-server/src/test/java/de/servicehealth/epa4all/integration/base/AbstractVsdTest.java
+++ b/rest-server/src/test/java/de/servicehealth/epa4all/integration/base/AbstractVsdTest.java
@@ -26,6 +26,7 @@ import de.servicehealth.epa4all.server.filetracker.download.EpaFileDownloader;
 import de.servicehealth.epa4all.server.idp.vaunp.VauNpProvider;
 import de.servicehealth.epa4all.server.insurance.InsuranceDataService;
 import de.servicehealth.epa4all.server.vsd.VsdService;
+import de.servicehealth.epa4all.server.ws.CETPPayload;
 import de.servicehealth.epa4all.server.ws.WebSocketPayload;
 import de.servicehealth.folder.WebdavConfig;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -94,6 +95,9 @@ public abstract class AbstractVsdTest extends AbstractWebdavIT {
 
     @Inject
     protected jakarta.enterprise.event.Event<WebSocketPayload> webSocketPayloadEvent;
+
+    @Inject
+    protected jakarta.enterprise.event.Event<CETPPayload> cetpPayloadEvent;
 
     @Inject
     protected InsuranceDataService insuranceDataService;
@@ -166,8 +170,8 @@ public abstract class AbstractVsdTest extends AbstractWebdavIT {
         RuntimeConfig runtimeConfig = new RuntimeConfig(konnektorDefaultConfig, defaultUserConfig.getUserConfigurations());
 
         CETPEventHandler cetpServerHandler = new CETPEventHandler(
-            webSocketPayloadEvent, insuranceDataService, entitlementService, epaFileDownloader, konnektorClient,
-            epaMultiService, cardlinkClient, runtimeConfig, featureConfig, epaCallGuard
+            webSocketPayloadEvent, cetpPayloadEvent, insuranceDataService, entitlementService, epaFileDownloader,
+            konnektorClient, epaMultiService, cardlinkClient, runtimeConfig, featureConfig, epaCallGuard
         );
         EmbeddedChannel channel = new EmbeddedChannel(cetpServerHandler);
 

--- a/rest-server/src/test/java/de/servicehealth/epa4all/integration/base/CETPEventHandlerProvider.java
+++ b/rest-server/src/test/java/de/servicehealth/epa4all/integration/base/CETPEventHandlerProvider.java
@@ -12,6 +12,7 @@ import de.servicehealth.epa4all.server.entitlement.EntitlementService;
 import de.servicehealth.epa4all.server.epa.EpaCallGuard;
 import de.servicehealth.epa4all.server.filetracker.download.EpaFileDownloader;
 import de.servicehealth.epa4all.server.insurance.InsuranceDataService;
+import de.servicehealth.epa4all.server.ws.CETPPayload;
 import de.servicehealth.epa4all.server.ws.WebSocketPayload;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -22,6 +23,9 @@ public class CETPEventHandlerProvider {
 
     @Inject
     jakarta.enterprise.event.Event<WebSocketPayload> webSocketPayloadEvent;
+
+    @Inject
+    jakarta.enterprise.event.Event<CETPPayload> cetpPayloadEvent;
 
     @Inject
     protected KonnektorDefaultConfig konnektorDefaultConfig;
@@ -60,8 +64,8 @@ public class CETPEventHandlerProvider {
         FeatureConfig featureCfg = mockFeatureConfig != null ? mockFeatureConfig : featureConfig;
         RuntimeConfig runtimeConfig = new RuntimeConfig(konnektorDefaultConfig, defaultUserConfig.getUserConfigurations());
         return new CETPEventHandler(
-            webSocketPayloadEvent, insuranceDataService, entitlementService, downloader, konnektorClient,
-            epaMultiService, mockCardlinkClient, runtimeConfig, featureCfg, epaCallGuard
+            webSocketPayloadEvent, cetpPayloadEvent, insuranceDataService, entitlementService, downloader,
+            konnektorClient, epaMultiService, mockCardlinkClient, runtimeConfig, featureCfg, epaCallGuard
         );
     }
 }

--- a/rest-server/src/test/java/de/servicehealth/epa4all/integration/bc/wiremock/CardInsertedPdfFailedEpaIT.java
+++ b/rest-server/src/test/java/de/servicehealth/epa4all/integration/bc/wiremock/CardInsertedPdfFailedEpaIT.java
@@ -6,16 +6,35 @@ import de.servicehealth.epa4all.integration.base.AbstractWiremockTest;
 import de.servicehealth.epa4all.integration.bc.wiremock.setup.CallInfo;
 import de.servicehealth.epa4all.server.filetracker.FileEventSender;
 import de.servicehealth.epa4all.server.filetracker.download.EpaFileDownloader;
+import de.servicehealth.epa4all.server.ws.CETPPayload;
 import io.quarkus.test.InjectMock;
+import io.quarkus.test.common.http.TestHTTPResource;
 import io.quarkus.test.junit.QuarkusMock;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.websocket.ClientEndpoint;
+import jakarta.websocket.ContainerProvider;
+import jakarta.websocket.OnError;
+import jakarta.websocket.OnMessage;
+import jakarta.websocket.OnOpen;
+import jakarta.websocket.Session;
+import jakarta.websocket.WebSocketContainer;
 import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.yasson.internal.JsonBindingBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.util.List;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -26,21 +45,63 @@ import static org.mockito.Mockito.verify;
 @TestProfile(WireMockProfile.class)
 public class CardInsertedPdfFailedEpaIT extends AbstractWiremockTest {
 
+    private static final LinkedBlockingDeque<String> MESSAGES = new LinkedBlockingDeque<>();
+
+    private final JsonbBuilder jsonbBuilder = new JsonBindingBuilder();
+
     @InjectMock
     FileEventSender fileEventSender;
 
+    @TestHTTPResource("/ws/cetp")
+    URI uri;
+
+    @ClientEndpoint
+    public static class Client {
+
+        @OnOpen
+        public void open(Session session) {
+            MESSAGES.add("CONNECT");
+            session.getAsyncRemote().sendText("ready");
+        }
+
+        @OnMessage
+        void message(String msg) {
+            MESSAGES.add(msg);
+        }
+
+        @OnError
+        public void onError(Session session, Throwable throwable) {
+            assertNull(throwable);
+        }
+    }
+
     @Test
     public void medicationPdfWasNotSentToCardlinkBecauseOfNotAuthorizedError() throws Exception {
-        String pdfError = "{\"errorCode\":\"internalError\",\"errorDetail\":\"Requestor not authorized\"}";
-        prepareVauStubs(List.of(
-            Pair.of("/epa/medication/render/v1/eml/pdf", new CallInfo().withErrorHeader(pdfError))
-        ));
-        prepareInformationStubs(204);
+        WebSocketContainer container = ContainerProvider.getWebSocketContainer();
+        try (Session session = container.connectToServer(CardInsertedPdfFailedEpaIT.Client.class, uri)) {
+            assertEquals("CONNECT", MESSAGES.poll(10, TimeUnit.SECONDS));
+            assertEquals("CETP SESSION is created", MESSAGES.poll(10, TimeUnit.SECONDS));
 
-        String kvnr = "X110587452";
-        EpaFileDownloader mockDownloader = mock(EpaFileDownloader.class);
-        receiveCardInsertedEvent(mockDownloader, null, kvnr);
-        verify(mockDownloader, never()).handleDownloadResponse(any(), any());
+            String pdfError = "{\"errorCode\":\"internalError\",\"errorDetail\":\"Requestor not authorized\"}";
+            prepareVauStubs(List.of(
+                Pair.of("/epa/medication/render/v1/eml/pdf", new CallInfo().withErrorHeader(pdfError))
+            ));
+            prepareInformationStubs(204);
+
+            String kvnr = "X110587452";
+            EpaFileDownloader mockDownloader = mock(EpaFileDownloader.class);
+            receiveCardInsertedEvent(mockDownloader, null, kvnr);
+            verify(mockDownloader, never()).handleDownloadResponse(any(), any());
+
+            String msg = MESSAGES.poll(20, TimeUnit.SECONDS);
+            assertNotNull(msg);
+            try (Jsonb build = jsonbBuilder.build()) {
+                CETPPayload cetpPayload = build.fromJson(msg, CETPPayload.class);
+                assertEquals("X110485291", cetpPayload.getKvnr());
+                assertTrue(cetpPayload.getError().contains("Problem with reading the data"));
+                assertNotNull(cetpPayload.getParameters());
+            }
+        }
     }
 
     @AfterEach


### PR DESCRIPTION
* Websocket endpoint `wss://epa4all:8090/ws/cetp` is added
* all registered ws sessions will get CETP event with additional attributes like smbcHandle/telematikId/kvnr