### PR TITLE
EPA-480: System should start even with a corrupted JCR repository

### DIFF
--- a/common-test/src/main/java/de/servicehealth/epa4all/common/TestUtils.java
+++ b/common-test/src/main/java/de/servicehealth/epa4all/common/TestUtils.java
@@ -23,7 +23,7 @@ import static org.apache.commons.io.FileUtils.deleteDirectory;
 
 public class TestUtils {
 
-    public final static String WIREMOCK = "wiremock/";
+    public final static String WIREMOCK = "wiremock" + File.separator;
     public final static String FIXTURES = WIREMOCK + "fixtures";
 
     private static final Logger log = LoggerFactory.getLogger(TestUtils.class.getName());
@@ -127,7 +127,7 @@ public class TestUtils {
     }
 
     public static Path getResourcePath(String... paths) {
-        return Path.of("src/test/resources", paths);
+        return Path.of("src" + File.separator + "test" + File.separator + "resources", paths);
     }
 
     public static String getStringFixture(String fileName) throws Exception {

--- a/common/src/main/java/de/servicehealth/logging/PublicLogFilter.java
+++ b/common/src/main/java/de/servicehealth/logging/PublicLogFilter.java
@@ -18,6 +18,7 @@ import java.util.logging.Filter;
 import java.util.logging.LogRecord;
 import java.util.stream.Collectors;
 
+import static de.servicehealth.utils.ServerUtils.makeSimplePath;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 @LoggingFilter(name = "de.servicehealth.logging.PublicLogFilter")
@@ -81,7 +82,7 @@ public class PublicLogFilter implements Filter {
 
     private static void reload() {
         Set<String> set = new HashSet<>();
-        String path = CONFIG.getOptionalValue(PERSONAL_DATA_PATH, String.class).orElse("secret/personal-data.dict");
+        String path = CONFIG.getOptionalValue(PERSONAL_DATA_PATH, String.class).orElse(makeSimplePath("secret", "personal-data.dict"));
         try {
             File file = new File(path);
             set.addAll(Files.readLines(file, UTF_8).stream()

--- a/common/src/main/java/de/servicehealth/utils/ServerUtils.java
+++ b/common/src/main/java/de/servicehealth/utils/ServerUtils.java
@@ -44,8 +44,31 @@ public class ServerUtils {
     private ServerUtils() {
     }
 
+    public static String makeSimplePath(String... paths) {
+        return makePath(false, false, paths);
+    }
+
+    public static String makePrefixPath(String... paths) {
+        return makePath(true, false, paths);
+    }
+
+    public static String makePostfixPath(String... paths) {
+        return makePath(false, true, paths);
+    }
+
+    public static String makePath(boolean prefix, boolean postfix, String... paths) {
+        String path = String.join(File.separator, paths);
+        if (prefix) {
+            path = File.separator + path;
+        }
+        if (postfix) {
+            path = path + File.separator;
+        }
+        return path;
+    }
+
     public static List<String> getPathParts(String path) {
-        return Arrays.stream(path.split("/")).filter(s -> !s.isEmpty()).toList();
+        return Arrays.stream(path.split("[/\\\\]+")).filter(s -> !s.isEmpty()).toList();
     }
 
     public static String getBaseUrl(String url) {

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/check/GitCheck.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/check/GitCheck.java
@@ -9,6 +9,7 @@ import jakarta.enterprise.event.Observes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.InputStream;
 import java.util.Map;
 import java.util.Properties;
@@ -23,7 +24,7 @@ public class GitCheck implements Check {
 
     private static final Properties properties = new Properties();
     static {
-        try (InputStream inputStream = GitCheck.class.getResourceAsStream("/git.properties")) {
+        try (InputStream inputStream = GitCheck.class.getResourceAsStream(File.separator + "git.properties")) {
             properties.load(inputStream);
         } catch (Exception e) {
             log.warn("Error while loading git.properties:" + e.getMessage());

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/jcr/JcrConfig.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/jcr/JcrConfig.java
@@ -49,7 +49,7 @@ public class JcrConfig {
     private volatile Map<String, List<String>> mixinConfigMap;
 
     public String getWorkspacesHome() {
-        return repositoryHome.getAbsolutePath() + "/workspaces";
+        return repositoryHome.getAbsolutePath() + File.separator + "workspaces";
     }
 
     public SimpleCredentials getCredentials() {

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/jcr/JcrService.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/jcr/JcrService.java
@@ -30,6 +30,7 @@ import static de.servicehealth.epa4all.server.jcr.Workspace.ROOT_FOLDER_NODE;
 import static de.servicehealth.epa4all.server.jcr.prop.JcrProp.EPA_NAMESPACE_URI;
 import static de.servicehealth.epa4all.server.jcr.prop.MixinProp.EPA_NAMESPACE_PREFIX;
 import static de.servicehealth.utils.ServerUtils.getPathParts;
+import static de.servicehealth.utils.ServerUtils.makePrefixPath;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
 
 @ApplicationScoped
@@ -80,7 +81,7 @@ public class JcrService extends StartableService {
             if (repositoryConfig.exists()) {
                 config = RepositoryConfig.create(repositoryConfig.toURI(), repositoryPath);
             } else {
-                InputStream is = JcrService.class.getResourceAsStream("/jcr/repository.xml");
+                InputStream is = JcrService.class.getResourceAsStream(makePrefixPath("jcr", "repository.xml"));
                 config = RepositoryConfig.create(is, repositoryPath);
             }
             Repository repository = RepositoryImpl.create(config);

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/jcr/Workspace.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/jcr/Workspace.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static de.servicehealth.epa4all.server.propsource.PropBuilder.SKIPPED_FILES;
+import static de.servicehealth.utils.ServerUtils.makePrefixPath;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.jcr.query.Query.JCR_SQL2;
 
@@ -44,7 +45,7 @@ public class Workspace {
 
     private String getConfigElement(String name, String configName, String elementTemplate) {
         File configFile = new File(jcrConfig.getConfigPath(), configName);
-        URL configUrl = Workspace.class.getResource("/jcr/" + configName);
+        URL configUrl = Workspace.class.getResource(makePrefixPath("jcr", configName));
         String configElement = getConfigurationParam(elementTemplate, configFile, configUrl);
         log.info(String.format("%s config = '%s'", name, configElement));
         return configElement;
@@ -62,7 +63,7 @@ public class Workspace {
             "\n<param name=\"indexingConfiguration\" value=\"%s\"/>"
         );
 
-        String path = jcrConfig.getWorkspacesHome() + "/" + telematikId;
+        String path = jcrConfig.getWorkspacesHome() + File.separator + telematikId;
         String configXml = """
             <?xml version="1.0" encoding="UTF-8"?>
             <Workspace name="%s">
@@ -71,7 +72,7 @@ public class Workspace {
                 </FileSystem>
                 <PersistenceManager class="org.apache.jackrabbit.core.persistence.bundle.BundleFsPersistenceManager"/>
                 <SearchIndex class="org.apache.jackrabbit.core.query.lucene.SearchIndex">
-                    <param name="path" value="%s/index"/>
+                    <param name="path" value="%s%sindex"/>
                     <param name="useSimpleFSDirectory" value="true"/>
                     <param name="supportHighlighting" value="true"/>
                     <param name="mergeFactor" value="10"/>
@@ -79,7 +80,7 @@ public class Workspace {
                     <param name="useCompoundFile" value="true"/>
                     <param name="extractorPoolSize" value="5"/>%s%s
                 </SearchIndex>
-            </Workspace>""".formatted(telematikId, path, path, tikaConfigElement, indexingConfigElement);
+            </Workspace>""".formatted(telematikId, path, path, File.separator, tikaConfigElement, indexingConfigElement);
 
         return new InputSource(new ByteArrayInputStream(configXml.getBytes(UTF_8)));
     }

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/propsource/PropBuilder.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/propsource/PropBuilder.java
@@ -244,9 +244,9 @@ public class PropBuilder {
         return node;
     }
 
-    public Node handleFolder(Session session, Node parentNode, File file, String fileName, boolean staleMixins) throws RepositoryException {
+    public Node handleFolder(Session session, Node parentNode, File file, String relName, boolean staleMixins) throws RepositoryException {
         try {
-            Node dirNode = parentNode.getNode(fileName);
+            Node dirNode = parentNode.getNode(relName);
             // it is implied that all orphan mixin properties are already removed in TypeService
             if (staleMixins) {
                 applyMixins(dirNode, TYPE_NT_FOLDER, file);
@@ -254,7 +254,7 @@ public class PropBuilder {
             }
             return dirNode;
         } catch (PathNotFoundException e) {
-            Node node = addNodeAndApplyMixins(parentNode, fileName, TYPE_NT_FOLDER, file);
+            Node node = addNodeAndApplyMixins(parentNode, relName, TYPE_NT_FOLDER, file);
             session.save();
             return node;
         }

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/rest/Epa.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/rest/Epa.java
@@ -1,6 +1,8 @@
 package de.servicehealth.epa4all.server.rest;
 
+import de.servicehealth.api.epa4all.EpaMultiService;
 import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.QueryParam;
@@ -16,7 +18,10 @@ import static jakarta.ws.rs.core.Response.Status.NO_CONTENT;
 
 @RequestScoped
 @Path("epa")
-public class Epa extends AbstractResource {
+public class Epa {
+
+    @Inject
+    protected EpaMultiService epaMultiService;
 
     @APIResponses({
         @APIResponse(responseCode = "204", description = "The patient has ePA"),

--- a/rest-server/src/test/java/de/servicehealth/epa4all/integration/base/AbstractWebdavIT.java
+++ b/rest-server/src/test/java/de/servicehealth/epa4all/integration/base/AbstractWebdavIT.java
@@ -35,7 +35,7 @@ public class AbstractWebdavIT {
         File repository = new File(tempDir, "repository");
         repository.mkdirs();
         when(jcrConfig.getRepositoryHome()).thenReturn(repository);
-        when(jcrConfig.getWorkspacesHome()).thenReturn(repository.getAbsolutePath() + "/workspaces");
+        when(jcrConfig.getWorkspacesHome()).thenReturn(repository.getAbsolutePath() + File.separator + "workspaces");
         when(jcrConfig.getMissingAuthMapping()).thenReturn("admin:admin");
         when(jcrConfig.getResourcePathPrefix()).thenReturn("/webdav2");
         when(jcrConfig.getAuthenticateHeader()).thenReturn(DEFAULT_AUTHENTICATE_HEADER);

--- a/rest-server/src/test/java/de/servicehealth/epa4all/integration/base/AbstractWiremockTest.java
+++ b/rest-server/src/test/java/de/servicehealth/epa4all/integration/base/AbstractWiremockTest.java
@@ -74,6 +74,7 @@ import static de.servicehealth.epa4all.common.TestUtils.WIREMOCK;
 import static de.servicehealth.epa4all.common.TestUtils.deleteFiles;
 import static de.servicehealth.epa4all.common.TestUtils.getResourcePath;
 import static de.servicehealth.epa4all.common.TestUtils.getTextFixture;
+import static de.servicehealth.utils.ServerUtils.makeSimplePath;
 import static jakarta.ws.rs.core.HttpHeaders.LOCATION;
 import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -340,7 +341,7 @@ public abstract class AbstractWiremockTest extends AbstractWebdavIT {
     }
 
     private VauServerStateMachine prepareVauServer() throws Exception {
-        Files.deleteIfExists(Path.of("target/vau3traffic.tgr"));
+        Files.deleteIfExists(Path.of(makeSimplePath("target", "vau3traffic.tgr")));
 
         KeyFactory keyFactory = KeyFactory.getInstance("EC");
         PKCS8EncodedKeySpec privateSpec = new PKCS8EncodedKeySpec(Files.readAllBytes(getResourcePath(VAU, "vau-sig-key.der")));

--- a/rest-server/src/test/java/de/servicehealth/epa4all/integration/bc/epa/IdpClientIT.java
+++ b/rest-server/src/test/java/de/servicehealth/epa4all/integration/bc/epa/IdpClientIT.java
@@ -73,7 +73,7 @@ public class IdpClientIT {
 
     @Test
     public void testGetVauNp() throws Exception {
-        EpaAPI epaAPI = epaMultiService.findEpaAPI("X110485291");
+        EpaAPI epaAPI = epaMultiService.findEpaAPI("X110624006");
         String backend = epaAPI.getBackend();
 
         // TODO disable vauNpProvider.onStart();

--- a/rest-server/src/test/java/de/servicehealth/epa4all/integration/bc/wiremock/ExpiredPatientDataIT.java
+++ b/rest-server/src/test/java/de/servicehealth/epa4all/integration/bc/wiremock/ExpiredPatientDataIT.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static de.servicehealth.epa4all.common.TestUtils.getBinaryFixture;
+import static de.servicehealth.utils.ServerUtils.makeSimplePath;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -80,13 +81,13 @@ public class ExpiredPatientDataIT extends AbstractJCRTest {
             assertEquals(1, hrefs.size());
             assertTrue(hrefs.getFirst().contains(kvnr + "/other/"));
 
-            File otherFolder = new File(tempDir.toFile(), "webdav/" + telematikId + "/" + kvnr + "/other");
+            File otherFolder = new File(tempDir.toFile(), makeSimplePath("webdav", telematikId, kvnr, "other"));
             File[] pdfFiles = otherFolder.listFiles(name -> name.getName().endsWith(".pdf"));
             assertNotNull(pdfFiles);
             assertEquals(1, pdfFiles.length);
             assertTrue(hrefs.getFirst().contains(pdfFiles[0].getName()));
         } else {
-            File kvnrFolder = new File(tempDir.toFile(), "webdav/" + telematikId + "/" + kvnr);
+            File kvnrFolder = new File(tempDir.toFile(), makeSimplePath("webdav", telematikId, kvnr));
             assertFalse(kvnrFolder.exists());
             assertEquals(0, hrefs.size());
 

--- a/rest-server/src/test/java/de/servicehealth/epa4all/integration/bc/wiremock/WebdavIT.java
+++ b/rest-server/src/test/java/de/servicehealth/epa4all/integration/bc/wiremock/WebdavIT.java
@@ -46,6 +46,7 @@ import static de.servicehealth.epa4all.server.rest.fileserver.paging.Paginator.X
 import static de.servicehealth.epa4all.server.rest.fileserver.paging.Paginator.X_SORT_BY;
 import static de.servicehealth.epa4all.server.rest.fileserver.paging.Paginator.X_TOTAL_COUNT;
 import static de.servicehealth.epa4all.server.rest.fileserver.paging.SortBy.Latest;
+import static de.servicehealth.utils.ServerUtils.makeSimplePath;
 import static de.servicehealth.utils.XmlUtils.createDocument;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -143,7 +144,7 @@ public class WebdavIT extends AbstractWiremockTest {
 
     private void printFilesInfo(String telematikId, String kvnr) {
         System.out.println("---------");
-        List<File> leafFiles = folderService.getLeafFiles(new File(tempDir.toFile(), "webdav/" + telematikId + "/" + kvnr));
+        List<File> leafFiles = folderService.getLeafFiles(new File(tempDir.toFile(), makeSimplePath("webdav", telematikId, kvnr)));
         for (File file : leafFiles) {
             System.out.println(file.getAbsolutePath() + " -> " + file.lastModified() + "\r\n");
         }
@@ -195,7 +196,7 @@ public class WebdavIT extends AbstractWiremockTest {
 
         TimeUnit.SECONDS.sleep(1);
 
-        File other = new File(tempDir.toFile(), "webdav/" + telematikId + "/" + kvnr + "/eab");
+        File other = new File(tempDir.toFile(), makeSimplePath("webdav", telematikId, kvnr, "eab"));
         File someFile = new File(other, "some.txt");
         boolean created = someFile.createNewFile();
         assertTrue(created);

--- a/rest-server/src/test/java/de/servicehealth/epa4all/integration/nonbc/TelematikAuthFilterIT.java
+++ b/rest-server/src/test/java/de/servicehealth/epa4all/integration/nonbc/TelematikAuthFilterIT.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import javax.net.ssl.SSLHandshakeException;
 import java.io.File;
 
+import static de.servicehealth.utils.ServerUtils.makeSimplePath;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,7 +30,7 @@ public class TelematikAuthFilterIT {
     @Test
     public void testHealthEndpoint() {
         File projectDir = new File("").getAbsoluteFile().getParentFile();
-        String path = projectDir.getAbsolutePath() + "/tls/server/trust-store/client/client.p12";
+        String path = makeSimplePath(projectDir.getAbsolutePath(), "tls", "server", "trust-store", "client", "client.p12");
         setupSSL(path, "changeit");
         given()
             .relaxedHTTPSValidation()
@@ -38,7 +39,7 @@ public class TelematikAuthFilterIT {
             .statusCode(200)
             .body(containsString("UP"));
 
-        setupSSL("/some-client-keystore.p12", "passpass");
+        setupSSL(File.separator + "some-client-keystore.p12", "passpass");
         assertThrows(SSLHandshakeException.class, () -> given()
             .relaxedHTTPSValidation()
             .when().get("https://localhost:8442/health")

--- a/rest-server/src/test/java/de/servicehealth/epa4all/unit/SmcbManagerTest.java
+++ b/rest-server/src/test/java/de/servicehealth/epa4all/unit/SmcbManagerTest.java
@@ -9,6 +9,7 @@ import java.security.cert.X509Certificate;
 
 import static de.servicehealth.epa4all.server.idp.IdpClient.BOUNCY_CASTLE_PROVIDER;
 import static de.servicehealth.utils.SSLUtils.extractTelematikIdFromCertificate;
+import static de.servicehealth.utils.ServerUtils.makePrefixPath;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class SmcbManagerTest {
@@ -17,7 +18,7 @@ class SmcbManagerTest {
 	void testExtractTelematikIdFromCertificate() {
 		try {
             CertificateFactory certFactory = CertificateFactory.getInstance("X.509", BOUNCY_CASTLE_PROVIDER);
-            InputStream inputStream = getClass().getResourceAsStream("/certs/SMC-B/Bad_ApothekeTESTONLY-80276883110000116352-aut-rsa.cer");
+            InputStream inputStream = getClass().getResourceAsStream(makePrefixPath("certs", "SMC-B", "Bad_ApothekeTESTONLY-80276883110000116352-aut-rsa.cer"));
             X509Certificate cert = (X509Certificate) certFactory.generateCertificate(inputStream);
             assertEquals("3-SMC-B-Testkarte-883110000116352", extractTelematikIdFromCertificate(cert));
 		} catch (CertificateException e) {


### PR DESCRIPTION
* added usage of the `File.separator` property instead of hardcoded "/"