### PR TITLE
Fix charset case and forward X-Requesting-Organization header to ePA

### DIFF
--- a/api-epa/src/main/java/de/servicehealth/api/epa4all/proxy/BaseProxyService.java
+++ b/api-epa/src/main/java/de/servicehealth/api/epa4all/proxy/BaseProxyService.java
@@ -89,7 +89,7 @@ public abstract class BaseProxyService {
             return List.of();
         } else {
             return List.of(
-                Pair.of(CONTENT_TYPE, "application/json; charset=UTF-8"),
+                Pair.of(CONTENT_TYPE, "application/json; charset=utf-8"),
                 Pair.of(CONTENT_LENGTH, String.valueOf(body.length))
             );
         }

--- a/api-epa/src/main/java/de/servicehealth/api/epa4all/proxy/FhirProxyService.java
+++ b/api-epa/src/main/java/de/servicehealth/api/epa4all/proxy/FhirProxyService.java
@@ -16,6 +16,7 @@ import org.apache.cxf.jaxrs.client.WebClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -106,7 +107,8 @@ public class FhirProxyService extends BaseProxyService implements IFhirProxy {
             );
         }
         List<Pair<String, String>> contentHeaders = buildContentHeaders(body);
-        ForwardRequest forwardRequest = new ForwardRequest(isGet, acceptHeaders, contentHeaders, body);
+        List<Pair<String, String>> additionalHeaders = extractAdditionalHeaders(headers);
+        ForwardRequest forwardRequest = new ForwardRequest(isGet, acceptHeaders, contentHeaders, additionalHeaders, body);
         epaMXBeanRegistry.registerRequest(backend);
         FhirResponse response = webClient
             .headers(map)
@@ -126,13 +128,29 @@ public class FhirProxyService extends BaseProxyService implements IFhirProxy {
         return builder.build();
     }
 
+    private static final Set<String> FORWARDED_HEADERS = Set.of(
+        "x-requesting-organization"
+    );
+
+    private List<Pair<String, String>> extractAdditionalHeaders(HttpHeaders headers) {
+        List<Pair<String, String>> result = new ArrayList<>();
+        if (headers != null) {
+            headers.getRequestHeaders().forEach((name, values) -> {
+                if (FORWARDED_HEADERS.contains(name.toLowerCase())) {
+                    values.forEach(value -> result.add(Pair.of(name, value)));
+                }
+            });
+        }
+        return result;
+    }
+
     @Override
     protected List<Pair<String, String>> buildContentHeaders(byte[] body) {
         if (body == null || body.length == 0) {
             return List.of();
         } else {
             return List.of(
-                Pair.of(CONTENT_TYPE, "application/fhir+json; charset=UTF-8"),
+                Pair.of(CONTENT_TYPE, "application/fhir+json; charset=utf-8"),
                 Pair.of(CONTENT_LENGTH, String.valueOf(body.length))
             );
         }

--- a/cxf-rt-transports-http-vau/src/main/java/de/servicehealth/epa4all/cxf/model/ForwardRequest.java
+++ b/cxf-rt-transports-http-vau/src/main/java/de/servicehealth/epa4all/cxf/model/ForwardRequest.java
@@ -13,7 +13,17 @@ public class ForwardRequest implements EpaRequest {
     private final boolean isGet;
     private final List<Pair<String, String>> acceptHeaders;
     private final List<Pair<String, String>> contentHeaders;
+    private final List<Pair<String, String>> additionalHeaders;
     private final byte[] body;
+
+    public ForwardRequest(
+        boolean isGet,
+        List<Pair<String, String>> acceptHeaders,
+        List<Pair<String, String>> contentHeaders,
+        byte[] body
+    ) {
+        this(isGet, acceptHeaders, contentHeaders, List.of(), body);
+    }
 
     public String getMethod() {
         return isGet ? "GET" : "POST";

--- a/cxf-rt-transports-http-vau/src/main/java/de/servicehealth/epa4all/cxf/provider/JsonbVauWriterProvider.java
+++ b/cxf-rt-transports-http-vau/src/main/java/de/servicehealth/epa4all/cxf/provider/JsonbVauWriterProvider.java
@@ -104,6 +104,9 @@ public class JsonbVauWriterProvider implements MessageBodyWriter, VauHeaders {
             List<Pair<String, String>> innerHeaders = prepareInnerHeaders(httpHeaders, backend, vauNp);
             innerHeaders.addAll(prepareAcceptHeaders(obj));
             innerHeaders.addAll(prepareContentHeaders(obj, payload));
+            if (obj instanceof ForwardRequest forwardRequest) {
+                innerHeaders.addAll(forwardRequest.getAdditionalHeaders());
+            }
 
             httpHeaders.remove(X_INSURANT_ID);
             httpHeaders.remove(VAU_NP);

--- a/medication-service/src/main/java/de/servicehealth/epa4all/medication/fhir/interceptor/FHIRRequestVAUInterceptor.java
+++ b/medication-service/src/main/java/de/servicehealth/epa4all/medication/fhir/interceptor/FHIRRequestVAUInterceptor.java
@@ -152,7 +152,7 @@ public class FHIRRequestVAUInterceptor implements HttpRequestInterceptor {
         request.removeHeader(request.getFirstHeader(X_BACKEND));
         String contentType = body.length == 0
             ? "\r\n" // extra blank line
-            : "Content-Type: application/fhir+json; charset=UTF-8\r\nContent-Length: " + body.length + "\r\n\r\n";
+            : "Content-Type: application/fhir+json; charset=utf-8\r\nContent-Length: " + body.length + "\r\n\r\n";
 
         byte[] httpRequest = (method + " " + path + " HTTP/1.1\r\n"
             + "Host: " + backend + "\r\n"


### PR DESCRIPTION
The ePA backend rejects uppercase charset=UTF-8 with an encoding error, and drops the X-Requesting-Organization header because the FHIR proxy never forwarded incoming client headers through the VAU tunnel.