### PR TITLE
EPA-529 * Find a solution for 3.1 - gematik.vau.skip-aut-cert-checks[1]=true for BITMARCK

### DIFF
--- a/common/src/main/java/de/servicehealth/gematik/A24624Verifier.java
+++ b/common/src/main/java/de/servicehealth/gematik/A24624Verifier.java
@@ -123,13 +123,17 @@ public class A24624Verifier {
      * {@code gematik.vau.skip-aut-cert-checks[i]=true}, and only ever throws on real fetch
      * failures. So a null {@code autCert} here means "intentional skip", logged as WARN.
      * <p>
-     * <b>Fail-closed under the production profile.</b> Under {@code pu} a null
-     * {@code autCert} is never accepted: the cert-dependent checks authenticate the
-     * server, so skipping them would reduce the connection to a TLS-pinning attack.
-     * The skip flag is honored only under {@code ru}/{@code ref} (test environments
-     * where the operator-side CertData endpoint may not yet be deployed). This is the
-     * security boundary itself — it does not trust the supplier or config to have
-     * gated correctly, so a bypass flag accidentally carried into PU config has no effect.
+     * <b>EPA-529: the skip flag is honored under {@code pu} as well.</b> A null
+     * {@code autCert} is accepted in every profile (including production), because some
+     * operators (e.g. BITMARCK epa-as-2) have not deployed the A_24957 / CertData endpoint
+     * and would otherwise be unreachable. The supplier is the per-backend policy gate.
+     * <p>
+     * <b>SECURITY WARNING:</b> skipping the cert-dependent checks leaves the VAU server
+     * cryptographically unauthenticated — only the OCSP/{@code exp} checks run, which a
+     * network MITM holding any leaf chaining to a TSL CA can forge. This re-opens advisory
+     * GHSA-vvh7-x6c7-46gh for the affected backend (reduced to a TLS-pinning attack). It is
+     * a deliberate, per-backend, config-gated trade-off — enable it only for a backend whose
+     * operator cannot serve CertData, and prefer pinning the real AUT cert (EPA-525) instead.
      */
     public void verify(SignedPublicVauKeys signedKeys, X509Certificate autCert) {
         if (!enabled) {
@@ -147,17 +151,14 @@ public class A24624Verifier {
 
         if (autCert == null) {
             if (puProfile) {
-                throw new A24624VerificationException(
-                    "A_24624-01 cert-dependent checks cannot be skipped under the PU (production) "
-                        + "profile: no AUT certificate is available for this backend, so the server "
-                        + "cannot be authenticated. Refusing the VAU session (fail-closed). Resolve by "
-                        + "deploying the backend's CertData endpoint (gemSpec_ePA_FdV §6.1.3 / A_24957) "
-                        + "or supplying a pinned AUT certificate out-of-band. "
-                        + "gematik.vau.skip-aut-cert-checks is ignored under PU by design.");
+                log.warn("DANGER (EPA-529): A_24624-01 cert-dependent checks SKIPPED under the PU "
+                    + "(production) profile — supplier returned no autCert "
+                    + "(gematik.vau.skip-aut-cert-checks for this backend). The VAU server is NOT "
+                    + "authenticated; this re-opens advisory GHSA-vvh7-x6c7-46gh for this backend.");
+            } else {
+                log.warn("A_24624-01 cert-dependent checks SKIPPED — supplier returned no autCert "
+                    + "(gematik.vau.skip-aut-cert-checks for this backend; ru/ref test environment).");
             }
-            log.warn("A_24624-01 cert-dependent checks SKIPPED — supplier returned no autCert "
-                + "(gematik.vau.skip-aut-cert-checks for this backend). Honored only because the "
-                + "profile is not PU (ru/ref test environment).");
             return;
         }
 

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/cdi/CertDataVauAutCertSupplier.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/cdi/CertDataVauAutCertSupplier.java
@@ -56,6 +56,11 @@ import static de.servicehealth.setup.SystemPropertyService.isPuRuRefProfile;
  * as defence in depth.
  * <p>
  * No-op in non-PU/RU/REF profiles ({@link A24624Verifier} is also off there).
+ * <p>
+ * <b>EPA-529:</b> a backend whose {@code gematik.vau.skip-aut-cert-checks[i]=true} returns
+ * {@code null} (no fetch) in EVERY profile, including pu. Under pu this is a deliberate,
+ * dangerous bypass — the VAU server is left unauthenticated and advisory GHSA-vvh7-x6c7-46gh
+ * is re-opened for that backend. See the WARN logs in {@code get()} / {@code loadSkipMap()}.
  */
 @ApplicationScoped
 public class CertDataVauAutCertSupplier implements VauAutCertSupplier {
@@ -119,9 +124,11 @@ public class CertDataVauAutCertSupplier implements VauAutCertSupplier {
             skipByBackend.put(backendIter.next(), flagIter.next());
         }
         if (puProfile && skipByBackend.containsValue(Boolean.TRUE)) {
-            log.warn("gematik.vau.skip-aut-cert-checks has true entries but the profile is PU "
-                + "(production): these are IGNORED. CertData is always fetched and the A_24624-01 "
-                + "cert-dependent checks always run under PU (fail-closed). Skip flags: {}", skipByBackend);
+            log.warn("DANGER (EPA-529): gematik.vau.skip-aut-cert-checks has true entries AND the "
+                + "profile is PU (production). As of EPA-529 these ARE HONORED under PU: the A_24624-01 "
+                + "cert-dependent checks are bypassed and the VAU server is NOT authenticated for the "
+                + "affected backend(s). This re-opens advisory GHSA-vvh7-x6c7-46gh (server-auth bypass) "
+                + "for those backends. Skip flags: {}", skipByBackend);
         }
     }
 
@@ -130,10 +137,16 @@ public class CertDataVauAutCertSupplier implements VauAutCertSupplier {
         if (!enabled) {
             return null;
         }
-        if (!puProfile && Boolean.TRUE.equals(skipByBackend.get(backend))) {
-            log.warn("Skipping AUT cert fetch for backend {} (gematik.vau.skip-aut-cert-checks=true). "
-                + "Cert-dependent A_24624 checks will be bypassed. Honored only because the profile "
-                + "is not PU (ru/ref test environment).", backend);
+        if (Boolean.TRUE.equals(skipByBackend.get(backend))) {
+            if (puProfile) {
+                log.warn("DANGER (EPA-529): skipping AUT cert fetch for backend {} under the PU "
+                    + "(production) profile (gematik.vau.skip-aut-cert-checks=true). The VAU server is "
+                    + "NOT cryptographically authenticated for this backend — a network MITM can hijack "
+                    + "the session (see advisory GHSA-vvh7-x6c7-46gh). Only OCSP/exp checks run.", backend);
+            } else {
+                log.warn("Skipping AUT cert fetch for backend {} (gematik.vau.skip-aut-cert-checks=true). "
+                    + "Cert-dependent A_24624 checks will be bypassed (ru/ref test environment).", backend);
+            }
             return null;
         }
         if (backend == null || certHash == null || certHash.length == 0) {

--- a/rest-server/src/main/resources/application.properties
+++ b/rest-server/src/main/resources/application.properties
@@ -151,21 +151,28 @@ ai.search.url=http://localhost:8030
 # temporal validity, role OID, and ES256 signature for that backend. Cert-independent checks
 # (OCSP parse, freshness, certStatus GOOD, exp) still run.
 #
-# FAIL-CLOSED UNDER PU: these flags are IGNORED under the pu (production) profile. There the
-# CertData fetch is always attempted and the full A_24624-01 chain always runs; a missing
-# AUT cert fails the VAU session rather than degrading to a TLS-pinning attack. Honored only
-# under ru/ref, which are test environments where an operator may not have deployed CertData.
+# EPA-529: these flags are HONORED UNDER PU as well. When set true for a backend, the CertData
+# fetch is skipped and the A_24624-01 cert-dependent checks are bypassed in EVERY profile,
+# including pu (production).
 #
-# Committed default is SAFE (never skip). The ru/ref opt-in below is the only place a skip is
-# enabled, so a flag can never be accidentally carried into a PU deployment.
+# !!! DANGER !!! Enabling a skip under pu leaves the VAU server cryptographically UNAUTHENTICATED
+# for that backend: a network MITM on the clinical LAN can hijack the session and read/modify all
+# inner ePA traffic. This re-opens published critical advisory GHSA-vvh7-x6c7-46gh ("no workaround")
+# for the affected backend. Use ONLY for a backend whose operator cannot serve CertData (A_24957),
+# and prefer pinning the real VAU AUT cert (EPA-525) over this bypass.
+#
+# Committed default is SAFE (never skip).
 gematik.vau.skip-aut-cert-checks[0]=false
 gematik.vau.skip-aut-cert-checks[1]=false
 
-# RU/REF only: BITMARCK epa-as-2 (backend index 1) has not deployed the CertData endpoint
-# (A_24957) yet — returns HTTP 400 as of 2026-05. IBM epa-as-1 (index 0) implements it.
-# These profile-scoped overrides are inert under pu (see fail-closed note above).
+# BITMARCK epa-as-2 (backend index 1) has not deployed the CertData endpoint (A_24957) yet —
+# returns HTTP 400 as of 2026-05. IBM epa-as-1 (index 0) implements it.
 %REF.gematik.vau.skip-aut-cert-checks[1]=true
 %RU.gematik.vau.skip-aut-cert-checks[1]=true
+# To bypass A_24624-01 for BITMARCK epa-as-2 in PRODUCTION (accepting the GHSA-vvh7-x6c7-46gh risk
+# above), uncomment the next line. This is the only deliberate, reviewable switch that degrades
+# production security — keep it commented unless BITMARCK genuinely cannot serve CertData.
+#%PU.gematik.vau.skip-aut-cert-checks[1]=true
 
 # EPA
 epa.backend[0]=epa-as-1.dev.epa4all.de:443


### PR DESCRIPTION
* `skip-aut-cert-checks` flag affects PU profile as well