### PR TITLE
EPA-525 - BITMARCK ePA: send x-useragent on CertData, component-wise …

### DIFF
--- a/common/src/main/java/de/servicehealth/gematik/A24624Verifier.java
+++ b/common/src/main/java/de/servicehealth/gematik/A24624Verifier.java
@@ -219,11 +219,31 @@ public class A24624Verifier {
             throw new A24624VerificationException("Failed to build expected OCSP CertificateID", e);
         }
         for (SingleResp sr : basicOcsp.getResponses()) {
-            if (!expected.equals(sr.getCertID())) {
+            CertificateID got = sr.getCertID();
+            // Compare CertID components, not CertificateID.equals(). BC's equals() compares the
+            // DER-encoded ASN.1 of the whole CertID including the AlgorithmIdentifier; SHA-1 can
+            // legally be encoded as `AlgorithmIdentifier(1.3.14.3.2.26, NULL)` or with parameters
+            // absent. Both forms hash identically but are not byte-equal, so equals() returns false
+            // on a fully-conformant response from an operator that uses the other form (observed
+            // against BITMARCK ePA in 2026-06). RFC 6960 / TUC_PKI_006 require matching the
+            // (hashAlg, issuerNameHash, issuerKeyHash, serial) tuple, which is what we do here.
+            boolean match = expected.getHashAlgOID().equals(got.getHashAlgOID())
+                && expected.getSerialNumber().equals(got.getSerialNumber())
+                && Arrays.equals(expected.getIssuerNameHash(), got.getIssuerNameHash())
+                && Arrays.equals(expected.getIssuerKeyHash(), got.getIssuerKeyHash());
+            if (!match) {
                 throw new A24624VerificationException(
-                    "OCSP SingleResponse CertID does not match AUT cert (serial=" + autCert.getSerialNumber() + ")");
+                    "OCSP SingleResponse CertID does not match AUT cert (serial=" + autCert.getSerialNumber()
+                        + ", expected=" + describeCertId(expected)
+                        + ", got=" + describeCertId(got) + ")");
             }
         }
+    }
+
+    private static String describeCertId(CertificateID id) {
+        return "serial=" + id.getSerialNumber()
+            + " issuerNameHash=" + java.util.HexFormat.of().formatHex(id.getIssuerNameHash())
+            + " issuerKeyHash=" + java.util.HexFormat.of().formatHex(id.getIssuerKeyHash());
     }
 
     private X509CertificateHolder findIssuerHolder(BasicOCSPResp basicOcsp, X509Certificate autCert) {

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/cdi/CertDataVauAutCertSupplier.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/cdi/CertDataVauAutCertSupplier.java
@@ -164,6 +164,7 @@ public class CertDataVauAutCertSupplier implements VauAutCertSupplier {
         try {
             HttpResponse<byte[]> resp = httpClient.send(
                 HttpRequest.newBuilder(URI.create(url))
+                    .header("x-useragent", epaConfig.getEpaUserAgent())
                     .timeout(HTTP_TIMEOUT)
                     .GET()
                     .build(),

--- a/rest-server/src/main/resources/application.properties
+++ b/rest-server/src/main/resources/application.properties
@@ -165,15 +165,6 @@ ai.search.url=http://localhost:8030
 gematik.vau.skip-aut-cert-checks[0]=false
 gematik.vau.skip-aut-cert-checks[1]=false
 
-# BITMARCK epa-as-2 (backend index 1) has not deployed the CertData endpoint (A_24957) yet —
-# returns HTTP 400 as of 2026-05. IBM epa-as-1 (index 0) implements it.
-%REF.gematik.vau.skip-aut-cert-checks[1]=true
-%RU.gematik.vau.skip-aut-cert-checks[1]=true
-# To bypass A_24624-01 for BITMARCK epa-as-2 in PRODUCTION (accepting the GHSA-vvh7-x6c7-46gh risk
-# above), uncomment the next line. This is the only deliberate, reviewable switch that degrades
-# production security — keep it commented unless BITMARCK genuinely cannot serve CertData.
-#%PU.gematik.vau.skip-aut-cert-checks[1]=true
-
 # EPA
 epa.backend[0]=epa-as-1.dev.epa4all.de:443
 epa.backend[1]=epa-as-2.dev.epa4all.de:443


### PR DESCRIPTION
…OCSP CertID compare

  - CertDataVauAutCertSupplier: include configured epa.user.agent on the CertData GET. BITMARCK rejects requests without it as malformedRequest (HTTP 400); IBM is tolerant.
  - A24624Verifier: compare CertID tuple (hashAlgOID, serial, issuerNameHash, issuerKeyHash) instead of CertificateID.equals(). BC's equals() is byte-exact on the whole CertID including the hash AlgorithmIdentifier; SHA-1 can encode parameters as NULL or absent, both produce identical hashes but aren't byte-equal. RFC 6960 only requires the tuple to match.