### PR TITLE
PU production fixes: TSL trust, VAU TLS, proxy framing, CETP keystore (EPA-545)

### DIFF
--- a/api-epa/src/main/java/de/servicehealth/api/epa4all/proxy/BaseProxyService.java
+++ b/api-epa/src/main/java/de/servicehealth/api/epa4all/proxy/BaseProxyService.java
@@ -94,4 +94,16 @@ public abstract class BaseProxyService {
             );
         }
     }
+
+    // Framing / hop-by-hop response headers must NOT be forwarded from the upstream ePA
+    // aktensystem: it returns Content-Length AND Transfer-Encoding together (a protocol
+    // violation) and strict fronting proxies (nginx) reject that with 502. The JAX-RS
+    // container recomputes framing for the actual payload it sends.
+    private static final Set<String> FRAMING_HEADERS = Set.of(
+        "transfer-encoding", "content-length", "connection", "keep-alive"
+    );
+
+    protected static boolean isFramingHeader(String name) {
+        return name != null && FRAMING_HEADERS.contains(name.toLowerCase());
+    }
 }

--- a/api-epa/src/main/java/de/servicehealth/api/epa4all/proxy/FhirProxyService.java
+++ b/api-epa/src/main/java/de/servicehealth/api/epa4all/proxy/FhirProxyService.java
@@ -95,7 +95,11 @@ public class FhirProxyService extends BaseProxyService implements IFhirProxy {
             .post(forwardRequest, FhirResponse.class);
 
         Response.ResponseBuilder builder = Response.status(response.getStatus()).entity(response.getPayload());
-        response.getHeaders().forEach(p -> builder.header(p.getKey(), p.getValue()));
+        response.getHeaders().forEach(p -> {
+            if (!isFramingHeader(p.getKey())) {
+                builder.header(p.getKey(), p.getValue());
+            }
+        });
         builder.type(ui5 ? APPLICATION_JSON_PATCH_JSON_TYPE : APPLICATION_JSON_TYPE);
         return builder.build();
     }

--- a/api-epa/src/main/java/de/servicehealth/api/epa4all/proxy/RenderProxyService.java
+++ b/api-epa/src/main/java/de/servicehealth/api/epa4all/proxy/RenderProxyService.java
@@ -87,7 +87,11 @@ public class RenderProxyService extends BaseProxyService {
             .post(forwardRequest, FhirResponse.class);
 
         Response.ResponseBuilder builder = Response.status(response.getStatus()).entity(response.getPayload());
-        response.getHeaders().forEach(p -> builder.header(p.getKey(), p.getValue()));
+        response.getHeaders().forEach(p -> {
+            if (!isFramingHeader(p.getKey())) {
+                builder.header(p.getKey(), p.getValue());
+            }
+        });
         builder.type(PDF.equals(format) ? APPLICATION_PDF : TEXT_HTML);
         return builder.build();
     }

--- a/common/src/main/java/de/servicehealth/gematik/GematikKeyStoreSpi.java
+++ b/common/src/main/java/de/servicehealth/gematik/GematikKeyStoreSpi.java
@@ -1,11 +1,15 @@
 package de.servicehealth.gematik;
 
-import de.gematik.pki.gemlibpki.tsl.TslValidator;
+import org.apache.xml.security.algorithms.JCEMapper;
+import org.apache.xml.security.signature.XMLSignature;
+import org.apache.xml.security.utils.Constants;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import javax.xml.XMLConstants;
@@ -87,7 +91,7 @@ public class GematikKeyStoreSpi extends KeyStoreSpi {
         try {
             byte[] tsl = fetchTsl();
             X509Certificate signer = loadSigningCertificate();
-            if (TslValidator.checkSignature(tsl, signer)) {
+            if (verifyTslSignature(tsl, signer)) {
                 certificates.putAll(extractCertificates(tsl));
                 creationDate = new Date();
                 log.info("Loaded {} trusted Gematik CA certificates for environment {}", certificates.size(), environment);
@@ -98,6 +102,69 @@ public class GematikKeyStoreSpi extends KeyStoreSpi {
             throw e;
         } catch (Exception e) {
             throw new IOException("Failed to load Gematik TSL for environment " + environment + ": " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Verifies the TSL's XAdES signature and that its signing certificate was issued by the
+     * pinned Gematik TSL-Signer-CA.
+     * <p>
+     * gemLibPki's {@code TslValidator.checkSignature} runs a full PKIX path build that cannot
+     * succeed here: the Gematik TSL-Signer-CA is an intermediate (issued by the TI root CA) and
+     * the TSL signature's {@code KeyInfo} carries only the signer certificate, so the path can
+     * never reach a self-signed anchor. We therefore verify directly: the signer must be issued
+     * by the pinned CA (our trust anchor) and the XML signature must be cryptographically valid.
+     * BouncyCastle is required for the Brainpool ECDSA curves used across the TI.
+     */
+    private boolean verifyTslSignature(byte[] tsl, X509Certificate pinnedIssuerCa) {
+        String previousProviderId = JCEMapper.getProviderId();
+        try {
+            org.apache.xml.security.Init.init();
+            JCEMapper.setProviderId(BouncyCastleProvider.PROVIDER_NAME);
+
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(true);
+            Document doc = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(tsl));
+            registerIdAttributes(doc.getDocumentElement());
+
+            NodeList sigNodes = doc.getElementsByTagNameNS(Constants.SignatureSpecNS, "Signature");
+            if (sigNodes.getLength() == 0) {
+                log.warn("TSL for environment {} carries no XML signature", environment);
+                return false;
+            }
+            XMLSignature signature = new XMLSignature((Element) sigNodes.item(0), "");
+            X509Certificate tslSigner = signature.getKeyInfo().getX509Certificate();
+            if (tslSigner == null) {
+                log.warn("TSL signature for environment {} carries no signing certificate", environment);
+                return false;
+            }
+            tslSigner.checkValidity();
+            tslSigner.verify(pinnedIssuerCa.getPublicKey(), BouncyCastleProvider.PROVIDER_NAME);
+            return signature.checkSignatureValue(tslSigner.getPublicKey());
+        } catch (Exception e) {
+            log.warn("TSL signature verification failed for environment {}: {}", environment, e.getMessage());
+            return false;
+        } finally {
+            if (previousProviderId != null) {
+                JCEMapper.setProviderId(previousProviderId);
+            }
+        }
+    }
+
+    /** Registers {@code Id}/{@code ID}/{@code id} attributes as XML IDs so XAdES same-document
+     *  references (e.g. {@code #SignedProperties-...}) resolve during signature validation. */
+    private static void registerIdAttributes(Node node) {
+        if (node.getNodeType() == Node.ELEMENT_NODE) {
+            Element element = (Element) node;
+            for (String attr : new String[]{"Id", "ID", "id"}) {
+                if (element.hasAttribute(attr)) {
+                    element.setIdAttribute(attr, true);
+                }
+            }
+        }
+        NodeList children = node.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            registerIdAttributes(children.item(i));
         }
     }
 
@@ -144,11 +211,13 @@ public class GematikKeyStoreSpi extends KeyStoreSpi {
         Document doc = db.parse(new ByteArrayInputStream(tsl));
 
         XPath xpath = XPathFactory.newInstance().newXPath();
-        // Mirror gk.sh: every X509Certificate (TSL namespace) whose grand-grand-parent
-        // (ServiceInformation) carries an extension element with text "oid_sak_aut".
+        // Trust every CA certificate listed in the TSL (TSL namespace). The narrower
+        // oid_sak_aut filter omitted the Komponenten-CAs (e.g. GEM.KOMP-CA8) that issue the
+        // TLS server certificates of TI components such as the ePA Aktensystem, so VAU/HTTPS
+        // handshakes to epa-as-*.prod.epa4all.de failed PKIX path building. The TSL is itself
+        // the authoritative TI trust list, so all its entries are valid trust anchors.
         String expr = "//*[local-name()='X509Certificate'"
-            + " and namespace-uri()='" + TSL_NS + "'"
-            + " and count(../../../*/*/*[text() = '" + OID_SAK_AUT + "']) > 0]";
+            + " and namespace-uri()='" + TSL_NS + "']";
         NodeList nodes;
         try {
             nodes = (NodeList) xpath.evaluate(expr, doc, XPathConstants.NODESET);
@@ -169,7 +238,7 @@ public class GematikKeyStoreSpi extends KeyStoreSpi {
             out.put(alias, cert);
         }
         if (out.isEmpty()) {
-            throw new IOException("TSL for environment " + environment + " contained no oid_sak_aut CA certificates");
+            throw new IOException("TSL for environment " + environment + " contained no CA certificates");
         }
         return out;
     }

--- a/common/src/main/java/de/servicehealth/gematik/ReloadableX509TrustManager.java
+++ b/common/src/main/java/de/servicehealth/gematik/ReloadableX509TrustManager.java
@@ -15,6 +15,9 @@ import java.security.cert.CertPathBuilderException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -144,7 +147,7 @@ public final class ReloadableX509TrustManager extends X509ExtendedTrustManager i
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
         try {
-            delegate.get().checkServerTrusted(chain, authType);
+            delegate.get().checkServerTrusted(withIssuerChain(chain), authType);
         } catch (CertificateException ex) {
             maybeTriggerReload(ex);
             throw ex;
@@ -154,7 +157,7 @@ public final class ReloadableX509TrustManager extends X509ExtendedTrustManager i
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
         try {
-            delegate.get().checkServerTrusted(chain, authType, socket);
+            delegate.get().checkServerTrusted(withIssuerChain(chain), authType, socket);
         } catch (CertificateException ex) {
             maybeTriggerReload(ex);
             throw ex;
@@ -164,11 +167,54 @@ public final class ReloadableX509TrustManager extends X509ExtendedTrustManager i
     @Override
     public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
         try {
-            delegate.get().checkServerTrusted(chain, authType, engine);
+            delegate.get().checkServerTrusted(withIssuerChain(chain), authType, engine);
         } catch (CertificateException ex) {
             maybeTriggerReload(ex);
             throw ex;
         }
+    }
+
+    /**
+     * Completes a peer chain whose issuer certificates are missing, using our own trust
+     * anchors. TI components (e.g. the ePA Aktensystem) commonly send only their leaf
+     * certificate, and the matching Komponenten-CA from the TSL is an intermediate, not a
+     * root. With BouncyCastle registered as the highest-priority provider (see IdpClient),
+     * JSSE's PKIX path building resolves to BC's CertPathBuilder, which locates issuers only
+     * in the presented chain — never among the trust anchors — so leaf-only chains fail with
+     * "No issuer certificate for certificate in certification path found". Appending the
+     * verified issuer(s) from the anchor set keeps validation semantics intact (the delegate
+     * still performs full PKIX checks) while making path building succeed.
+     */
+    private X509Certificate[] withIssuerChain(X509Certificate[] chain) {
+        if (chain == null || chain.length == 0) {
+            return chain;
+        }
+        List<X509Certificate> extended = new ArrayList<>(Arrays.asList(chain));
+        X509Certificate last = extended.get(extended.size() - 1);
+        X509Certificate[] anchors = delegate.get().getAcceptedIssuers();
+        for (int depth = 0; depth < 6; depth++) {
+            if (last.getSubjectX500Principal().equals(last.getIssuerX500Principal())) {
+                break;
+            }
+            X509Certificate issuer = null;
+            for (X509Certificate anchor : anchors) {
+                if (anchor.getSubjectX500Principal().equals(last.getIssuerX500Principal())) {
+                    try {
+                        last.verify(anchor.getPublicKey());
+                        issuer = anchor;
+                        break;
+                    } catch (Exception ignored) {
+                        // same subject DN but different key (CA re-key) — keep looking
+                    }
+                }
+            }
+            if (issuer == null || extended.contains(issuer)) {
+                break;
+            }
+            extended.add(issuer);
+            last = issuer;
+        }
+        return extended.toArray(new X509Certificate[0]);
     }
 
     private void maybeTriggerReload(CertificateException ex) {

--- a/cxf-rt-transports-http-vau/src/main/java/de/servicehealth/epa4all/cxf/client/ClientFactory.java
+++ b/cxf-rt-transports-http-vau/src/main/java/de/servicehealth/epa4all/cxf/client/ClientFactory.java
@@ -36,6 +36,8 @@ import org.apache.cxf.transport.http.HTTPConduit;
 import org.apache.cxf.transports.http.configuration.HTTPClientPolicy;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import java.util.List;
 import java.util.Set;
 
@@ -52,6 +54,9 @@ public class ClientFactory extends StartableService {
     @Named("gematikSSLContext")
     SSLContext gematikSslContext;
 
+    @Inject
+    X509TrustManager gematikTrustManager;
+
     @Override
     public int getPriority() {
         return CxfClientFactoryPriority;
@@ -59,7 +64,12 @@ public class ClientFactory extends StartableService {
 
     public void doStart() {
         Bus globalBus = BusFactory.getDefaultBus();
-        globalBus.setProperty("force.urlconnection.http.conduit", false);
+        // CXF's HttpClientHTTPConduit (java.net.http based) ignores TLSClientParameters, so the
+        // VAU/ePA WebClients fell back to the JVM default SSLContext (cacerts, no TI CAs) and failed
+        // PKIX. Force the URLConnection conduit, which honours the per-conduit trust config set in
+        // initConduit() (our Gematik trust manager: all TSL CAs + leaf-only TI chain completion).
+        // Scoped to this bus's CXF clients, so the IDP client and others are unaffected.
+        globalBus.setProperty("force.urlconnection.http.conduit", true);
         globalBus.setProperty("bus.jmx.usePlatformMBeanServer", TRUE);
         globalBus.setProperty("bus.jmx.enabled", TRUE);
 
@@ -143,6 +153,11 @@ public class ClientFactory extends StartableService {
         // setDisableCNCheck and setHostnameVerifier should not be set
         // to stick to HttpClientHTTPConduit (see HttpClientHTTPConduit.setupConnection)
         tlsParams.setSslContext(gematikSslContext);
+        // The JDK-HttpClient conduit builds its SSLContext from the trust managers and does not
+        // honour a bare setSslContext(...), so without this the VAU/ePA handshake fell back to the
+        // JDK default trust store (no TI CAs) and failed PKIX. Set our Gematik trust manager
+        // (all TSL CAs + leaf-only chain completion) explicitly.
+        tlsParams.setTrustManagers(new TrustManager[]{ gematikTrustManager });
         conduit.setTlsClientParameters(tlsParams);
     }
 }

--- a/rest-server/src/main/java/de/servicehealth/epa4all/server/cetp/SecretsManagerService.java
+++ b/rest-server/src/main/java/de/servicehealth/epa4all/server/cetp/SecretsManagerService.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.X509TrustManager;
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.FileInputStream;
 import java.util.Optional;
 
@@ -55,6 +56,37 @@ public class SecretsManagerService implements ISecretsManager {
 
     @Override
     public KeyManagerFactory getKeyManagerFactory(KonnektorConfig config) {
+        // The Konnektor's CETP TLS client offers RSA-only cipher suites, while the
+        // client-system cert used for SOAP mTLS is ECC. Allow a dedicated (RSA)
+        // keystore for the CETP server: path via system property, password via env
+        // so it never shows up in argv/ps.
+        //
+        // Multi-Konnektor: each secunet Konnektor PINS the client-system cert its
+        // provider registered, so one global keystore can only ever serve pharmacies
+        // whose Konnektors trust the same cert. A per-Konnektor cetp-server.p12 in
+        // the konnektoren/<port>/ dir takes precedence; password from
+        // CETP_SERVER_STORE_PASSWORD_<port>, falling back to the shared env var.
+        File perKonnektorStore = new File(config.getFolder(), "cetp-server.p12");
+        if (perKonnektorStore.isFile()) {
+            String perKonnektorPass = System.getenv().getOrDefault(
+                "CETP_SERVER_STORE_PASSWORD_" + config.getCetpPort(),
+                System.getenv().getOrDefault("CETP_SERVER_STORE_PASSWORD", "")
+            );
+            try (FileInputStream inputStream = new FileInputStream(perKonnektorStore)) {
+                return createSSLContextBundle(inputStream, perKonnektorPass, trustManager, PKCS12).getKeyManagerFactory();
+            } catch (Exception e) {
+                log.error("Could not create keyManagerFactory from " + perKonnektorStore.getAbsolutePath(), e);
+            }
+        }
+        String cetpStore = System.getProperty("cetp.server.cert.auth.store.file");
+        if (cetpStore != null) {
+            String cetpPass = System.getenv().getOrDefault("CETP_SERVER_STORE_PASSWORD", "");
+            try (FileInputStream inputStream = new FileInputStream(cetpStore)) {
+                return createSSLContextBundle(inputStream, cetpPass, trustManager, PKCS12).getKeyManagerFactory();
+            } catch (Exception e) {
+                log.error("Could not create keyManagerFactory from cetp.server.cert.auth.store.file", e);
+            }
+        }
         IUserConfigurations userConfigurations = config.getUserConfigurations();
         String certificate = userConfigurations.getClientCertificate();
         String password = userConfigurations.getClientCertificatePassword();


### PR DESCRIPTION
## Context

We've been running epa4all against the **production** Telematikinfrastruktur (profile `PU`) for a pharmacy connected via Red Medical, and got the full chain working end-to-end: CETP card event → ReadVSD → entitlement → eML/eMP retrieval via the VAU. Thanks for the project!

Getting there against `PU` required a handful of changes. This PR collects the ones we believe are generally useful for anyone running epa4all against production, as separate reviewable commits. Related tracking ticket on your side: **EPA-545**. (A companion PR to `lib-cetp` covers the CETP-server TLS side.)

We can't claim every diagnosis is 100% correct — but without these it did not run against `PU`, and with them it runs stably. Happy to adjust any of them to your preferences.

## Commits

1. **TSL: verify signature directly + trust all TSL CAs** — `gemLibPki`'s `TslValidator.checkSignature` runs a full PKIX path build that can't succeed (TSL-Signer-CA is an intermediate; the signature's `KeyInfo` carries only the signer cert). We verify directly against the pinned TSL-Signer-CA + XAdES signature (BouncyCastle for the Brainpool curves). Separately, `extractCertificates` now trusts every CA in the TSL, not just `oid_sak_aut` — the narrower filter dropped the Komponenten-CAs that issue the ePA Aktensystem's TLS server certs, so VAU handshakes failed.
2. **VAU TLS: complete leaf-only chains + force URLConnection conduit** — TI servers often send leaf-only chains; with BouncyCastle as the top-priority provider, PKIX path building can't reach the anchors, so we append the verified issuer before delegating. And CXF's `HttpClientHTTPConduit` silently ignores `TLSClientParameters`, so VAU clients fell back to `cacerts`; we force the URLConnection conduit and set the Gematik trust manager explicitly (scoped to this bus so the IDP client is unaffected).
3. **proxy: strip framing/hop-by-hop headers** — the Aktensystem returns `Content-Length` **and** `Transfer-Encoding` together (protocol violation); forwarding both makes strict fronting proxies (nginx) return 502 on `/render` and `/fhir`.
4. **CETP server: dedicated per-Konnektor RSA keystore** — the secunet Konnektor's CETP push offers RSA-only suites and pins the provider-registered client-system cert. Adds a per-Konnektor `konnektoren/<port>/cetp-server.p12` (password via env), needed for multi-Konnektor instances where each Konnektor pins a different cert.

Each commit stands alone; happy to split into separate PRs if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
