### PR TITLE
Hotfix: pin HTTP/1.1 for the gematik TSL download

### DIFF
--- a/common/src/main/java/de/servicehealth/gematik/GematikKeyStoreSpi.java
+++ b/common/src/main/java/de/servicehealth/gematik/GematikKeyStoreSpi.java
@@ -105,6 +105,10 @@ public class GematikKeyStoreSpi extends KeyStoreSpi {
         String url = configValue(OVERRIDE_TSL_URL_PROP + "." + environment.name(), environment.getTslUrl());
         log.debug("Downloading Gematik TSL from {}", url);
         try (HttpClient client = HttpClient.newBuilder()
+            // Pin HTTP/1.1: the TSL URL is plaintext HTTP, so the default HTTP_2
+            // triggers an h2c upgrade that some middleboxes answer by closing the
+            // connection without a status line ("header parser received no bytes").
+            .version(HttpClient.Version.HTTP_1_1)
             .connectTimeout(HTTP_TIMEOUT)
             .followRedirects(HttpClient.Redirect.NORMAL)
             .build()) {


### PR DESCRIPTION
## Problem

Die Engine bricht beim Start ab, während sie den gematik-TSL-Truststore aufbaut:

```
CachingGematikLoader - Fetching fresh TSL truststore for environment PU
Caused by: java.io.IOException: HTTP/1.1 header parser received no bytes
Caused by: java.io.EOFException: EOF reached while reading
  -> Error injecting javax.net.ssl.SSLContext ...ClientFactory.gematikSslContext
```

Ohne `SSLContext` ist die Engine unbrauchbar. Betroffen sind mindestens zwei
Kunden; auf `main` (c428b4c1) und früher reproduzierbar an den betroffenen
Standorten.

## Ursache

`GematikKeyStoreSpi.fetchTsl()` baut den `HttpClient` ohne Protokollversion.
`HttpClient.Builder` verwendet als Vorgabe `Version.HTTP_2`. Die TSL-URL ist
Klartext-HTTP (`http://download.crl.ti-dienste.de/...`), ALPN steht also nicht
zur Verfügung, und der JDK-Client versucht stattdessen einen h2c-Upgrade:

```
Connection: Upgrade, HTTP2-Settings
Upgrade: h2c
HTTP2-Settings: <base64>
```

Transparente Proxies, Webfilter und die HTTP-Proxies mancher Konnektor-/Router-
Modelle kennen diese Header nicht zwingend und schließen die Verbindung, ohne
ein einziges Antwortbyte zu senden. Genau das meldet
`jdk.internal.net.http.Http1HeaderParser`: Verbindung stand, Request ging raus,
Gegenstelle schloss vor der Statuszeile. Ein Transportsymptom, kein TLS-, DNS-
oder Signaturproblem.

Belegt durch das Kundenlog: 30 Sekunden vor dem Java-Fehler lädt der .NET-
Wrapper auf demselben Rechner von derselben URL die Datei problemlos. Der
Unterschied ist die Protokollversion — .NETs `HttpClient` fragt HTTP/1.1 an.
Gegen den Live-Endpunkt geprüft: `200 OK`, ausgehandelte Version 1.1,
580 351 Byte. Der Server spricht ausschließlich HTTP/1.1, der Upgrade-Versuch
bringt also selbst dann nichts, wenn er durchgeht.

## Änderung

HTTP/1.1 in `fetchTsl()` festlegen — eine Zeile, keine Verhaltensänderung auf
einem sauberen Netzwerkpfad:

```java
try (HttpClient client = HttpClient.newBuilder()
    .version(HttpClient.Version.HTTP_1_1)
    .connectTimeout(HTTP_TIMEOUT)
    .followRedirects(HttpClient.Redirect.NORMAL)
    .build()) {
```

